### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: cdisc-proxy
   RUST_VERSION: stable


### PR DESCRIPTION
Potential fix for [https://github.com/tomhub/cdisc-proxy/security/code-scanning/8](https://github.com/tomhub/cdisc-proxy/security/code-scanning/8)

To fix the problem, explicitly restrict the GITHUB_TOKEN permissions for jobs that do not need write access. The simplest, least intrusive approach is to add a top‑level `permissions` block that sets `contents: read` (and any other read‑only scopes you might need in the future). This will apply to all jobs except those that override permissions themselves. The `release` job already declares `permissions: contents: write`, so it will continue to function as before.

Concretely:
- Add a root‑level `permissions` section just after the `on:` block (before `env:`). Set `contents: read`, which is sufficient for the existing jobs that only check out, download, and upload artifacts (`build`, `package-deb`, `package-rpm`, `package-macos`).
- Leave the existing `permissions` block on the `release` job unchanged, so it still has `contents: write` as required by `softprops/action-gh-release`.

No new methods, imports, or external tools are required; this is a pure YAML configuration change in `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
